### PR TITLE
fix: sigin 실패시 응답 결과 추가

### DIFF
--- a/src/main/java/back/ahwhew/controller/UserController.java
+++ b/src/main/java/back/ahwhew/controller/UserController.java
@@ -105,7 +105,7 @@ public class UserController {
         UserEntity user = service.getByCredentials(dto.getUserId(), dto.getPassword(), passwordEncoder);
 
         log.info("user: {}",user);
-        if(user != null){
+        if(user.getUserId() != null){
             log.info("user is not null");
             // 이메일, 비번으로 찾은 유저 있음 = 로그인 성공
             final String token = tokenProvider.createAccessToken(user);
@@ -127,10 +127,10 @@ public class UserController {
         } else {
             // userId, 비번으로 찾은 유저 없음 = 로그인 실패
             ResponseDTO resDTO = ResponseDTO.builder()
-                    .error("Login failed")
+                    .error(user.getAge()) // service에서 로그인 실패 사유를 age에 담아 보내기 때문
                     .build();
 
-            return ResponseEntity.badRequest().body(resDTO);
+            return ResponseEntity.status(401).body(resDTO);
         }
     }
     @PostMapping("/newToken")

--- a/src/main/java/back/ahwhew/service/UserService.java
+++ b/src/main/java/back/ahwhew/service/UserService.java
@@ -69,10 +69,22 @@ public class UserService {
         if(originalUser != null && encoder.matches(password, originalUser.getPassword())) {
             log.info("samePassword");
             return originalUser;
+        }else if(originalUser == null){
+            log.info("wrong userId");
+            UserEntity user = new UserEntity();
+            user.setAge("wrong userId"); // age와 오류 메세지가 중복 가능섬이 없기 때문에 사용
+            return user;
+        }else if(!encoder.matches(password, originalUser.getPassword())){
+            log.info("wrong password");
+            UserEntity user = new UserEntity();
+            user.setAge("wrong password");
+            return user;
+        }else{
+            log.info("signin error");
+            UserEntity user = new UserEntity();
+            user.setAge("signin error");
+            return user;
         }
-
-        log.info("wrongPassword");
-        return null;
     }
 
     public UserEntity getById(UUID id){


### PR DESCRIPTION
1. userId가 틀린 경우(db에 동일한 userId가 없는 경우)
2. password가 틀린 경우(db에 userId가 등록되어있지만 db에 등록된 password와 다른 경우)
3. 이외의 경우(웬만하면 없을 것으로 예상)
를 추가 하였습니다.
close #103